### PR TITLE
Split routes with express routers - site functionality remains the same

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,12 +2,11 @@ const express = require("express");
 const app = express();
 const path = require("path");
 const ejsMate = require("ejs-mate");
-const Landmark = require("./models/landmark");
-const Review = require("./models/review");
 const methodOverride = require("method-override");
 const ExpressError = require("./util/ExpressError");
-const catchAsync = require("./util/catchAsync");
-const { landmarkSchema, reviewSchema } = require("./schemas");
+
+const landmarkRouter = require("./routes/landmarks");
+const reviewRouter = require("./routes/reviews");
 
 app.engine("ejs", ejsMate);
 app.set("view engine", "ejs");
@@ -21,133 +20,35 @@ mongoose.connect("mongodb://localhost:27017/seersite-test", {});
 const db = mongoose.connection;
 db.on("error", console.error.bind(console, "Error connecting to DB:"));
 db.once("open", () => {
-  console.log("Connect to DB.");
+    console.log("Connect to DB.");
 });
 
 app.use(express.static(path.join(__dirname, "public")));
 
 app.use((req, res, next) => {
-  req.requestTime = Date.now();
-  next();
+    req.requestTime = Date.now();
+    next();
 });
 
 app.get("/", (req, res) => {
-  res.render("home");
+    res.render("home");
 });
 
-app.get(
-  "/landmarks",
-  catchAsync(async (req, res) => {
-    const landmarks = await Landmark.find({});
-    res.render("landmarks/index", { landmarks });
-  })
-);
+app.use("/landmarks", landmarkRouter);
 
-app.get("/landmarks/new", (req, res) => {
-  res.render("landmarks/new");
-});
-
-const validateLandmark = (req, res, next) => {
-  const result = landmarkSchema.validate(req.body);
-  if (result.error) {
-    const err = result.error.details.map((e) => e.message).join(";");
-    throw new ExpressError(err, 400);
-  } else {
-    next();
-  }
-};
-
-const validateReview = (req, res, next) => {
-  const result = reviewSchema.validate(req.body);
-  if (result.error) {
-    const err = result.error.details.map((e) => e.message).join(";");
-    throw new ExpressError(err, 400);
-  } else {
-    next();
-  }
-};
-
-app.post(
-  "/landmarks",
-  validateLandmark,
-  catchAsync(async (req, res) => {
-    const landmark = new Landmark(req.body.landmark);
-    await landmark.save();
-    res.redirect(`/landmarks/${landmark._id}`);
-  })
-);
-
-//Place variable entries below others with similar paths, or express will think another route is a parameter.
-app.get(
-  "/landmarks/:id",
-  catchAsync(async (req, res) => {
-    const landmark = await Landmark.findById(req.params.id).populate("reviews");
-    if (!landmark) throw new ExpressError("Landmark ID not found", 400);
-    res.render("landmarks/show", { landmark });
-  })
-);
-
-app.get(
-  "/landmarks/:id/edit",
-  catchAsync(async (req, res) => {
-    const landmark = await Landmark.findById(req.params.id);
-    if (!landmark) throw new ExpressError("Landmark ID not found", 400);
-    res.render("landmarks/edit", { landmark });
-  })
-);
-
-app.patch(
-  "/landmarks/:id/edit",
-  validateLandmark,
-  catchAsync(async (req, res) => {
-    const landmark = await Landmark.findByIdAndUpdate(req.params.id, req.body.landmark);
-    if (!landmark) throw new ExpressError("Landmark ID not found", 400);
-    res.redirect(`/landmarks/${landmark._id}`);
-  })
-);
-
-app.delete(
-  "/landmarks/:id",
-  catchAsync(async (req, res) => {
-    await Landmark.findByIdAndDelete(req.params.id);
-    res.redirect(`/landmarks/`);
-  })
-);
-
-app.post(
-  "/landmarks/:id/reviews",
-  validateReview,
-  catchAsync(async (req, res) => {
-    const landmark = await Landmark.findById(req.params.id);
-    const review = new Review(req.body.review);
-    landmark.reviews.push(review);
-    await review.save();
-    await landmark.save();
-    res.redirect(`/landmarks/${landmark._id}`);
-  })
-);
-
-app.delete(
-  "/landmarks/:id/reviews/:reviewId",
-  catchAsync(async (req, res) => {
-    const { id, reviewId } = req.params;
-    await Landmark.findByIdAndUpdate(id, { $pull: { reviews: reviewId } });
-    await Review.findByIdAndDelete(reviewId);
-    res.redirect(`/landmarks/${id}`);
-  })
-);
+app.use("/landmarks/:id/reviews", reviewRouter);
 
 app.all("*", (req, res, next) => {
-  next(new ExpressError("Page not found.", 404));
+    next(new ExpressError("Page not found.", 404));
 });
 
 app.use((err, req, res, next) => {
-  const { statusCode = 500 } = err;
-  if (!err.message) err.message = "Server encountered an error.";
-  console.log(err);
-  res.status(statusCode).render("error", { err, statusCode });
+    const { statusCode = 500 } = err;
+    if (!err.message) err.message = "Server encountered an error.";
+    //console.log(err);
+    res.status(statusCode).render("error", { err, statusCode });
 });
 
 app.listen(3000, () => {
-  console.log("Server open on port 3000");
+    console.log("Server open on port 3000");
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "ejs": "^3.1.9",
         "ejs-mate": "^4.0.0",
         "express": "^4.18.2",
+        "express-session": "^1.17.3",
         "joi": "^17.11.0",
         "method-override": "^3.0.0",
         "mongoose": "^8.0.3",
@@ -377,6 +378,32 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-session": {
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.3.tgz",
+      "integrity": "sha512-4+otWXlShYlG1Ma+2Jnn+xgKUZTMJ5QD3YvfilX3AcocOAbIkVylSWEklzALe/+Pu4qV6TYBj5GwOBFfdKqLBw==",
+      "dependencies": {
+        "cookie": "0.4.2",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/filelist": {
@@ -841,6 +868,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -903,6 +938,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/range-parser": {
@@ -1086,6 +1129,17 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "ejs": "^3.1.9",
     "ejs-mate": "^4.0.0",
     "express": "^4.18.2",
+    "express-session": "^1.17.3",
     "joi": "^17.11.0",
     "method-override": "^3.0.0",
     "mongoose": "^8.0.3",

--- a/routes/landmarks.js
+++ b/routes/landmarks.js
@@ -1,0 +1,84 @@
+const express = require("express");
+const router = express.Router();
+const catchAsync = require("../util/catchAsync");
+const Landmark = require("../models/landmark");
+
+const ExpressError = require("../util/ExpressError");
+
+const { landmarkSchema } = require("../schemas");
+
+const validateLandmark = (req, res, next) => {
+    const result = landmarkSchema.validate(req.body);
+    if (result.error) {
+        const err = result.error.details.map((e) => e.message).join(";");
+        throw new ExpressError(err, 400);
+    } else {
+        next();
+    }
+};
+
+router.get(
+    "/",
+    catchAsync(async (req, res) => {
+        const landmarks = await Landmark.find({});
+        res.render("landmarks/index", { landmarks });
+    })
+);
+
+router.get("/new", (req, res) => {
+    res.render("landmarks/new");
+});
+
+router.post(
+    "/",
+    validateLandmark,
+    catchAsync(async (req, res) => {
+        const landmark = new Landmark(req.body.landmark);
+        await landmark.save();
+        res.redirect(`/landmarks/${landmark._id}`);
+    })
+);
+
+//Place variable entries below others with similar paths, or express will think another route is a parameter.
+router.get(
+    "/:id",
+    catchAsync(async (req, res) => {
+        const landmark = await Landmark.findById(req.params.id).populate(
+            "reviews"
+        );
+        if (!landmark) throw new ExpressError("Landmark ID not found", 400);
+        res.render("landmarks/show", { landmark });
+    })
+);
+
+router.get(
+    "/:id/edit",
+    catchAsync(async (req, res) => {
+        const landmark = await Landmark.findById(req.params.id);
+        if (!landmark) throw new ExpressError("Landmark ID not found", 400);
+        res.render("landmarks/edit", { landmark });
+    })
+);
+
+router.patch(
+    "/:id/edit",
+    validateLandmark,
+    catchAsync(async (req, res) => {
+        const landmark = await Landmark.findByIdAndUpdate(
+            req.params.id,
+            req.body.landmark
+        );
+        if (!landmark) throw new ExpressError("Landmark ID not found", 400);
+        res.redirect(`/landmarks/${landmark._id}`);
+    })
+);
+
+router.delete(
+    "/:id",
+    catchAsync(async (req, res) => {
+        await Landmark.findByIdAndDelete(req.params.id);
+        res.redirect(`/landmarks/`);
+    })
+);
+
+module.exports = router;

--- a/routes/reviews.js
+++ b/routes/reviews.js
@@ -1,0 +1,41 @@
+const express = require("express");
+const router = express.Router({ mergeParams: true });
+const catchAsync = require("../util/catchAsync");
+const { reviewSchema } = require("../schemas");
+const Landmark = require("../models/landmark");
+const Review = require("../models/review");
+
+const validateReview = (req, res, next) => {
+    const result = reviewSchema.validate(req.body);
+    if (result.error) {
+        const err = result.error.details.map((e) => e.message).join(";");
+        throw new ExpressError(err, 400);
+    } else {
+        next();
+    }
+};
+
+router.post(
+    "/",
+    validateReview,
+    catchAsync(async (req, res) => {
+        const landmark = await Landmark.findById(req.params.id);
+        const review = new Review(req.body.review);
+        landmark.reviews.push(review);
+        await review.save();
+        await landmark.save();
+        res.redirect(`/landmarks/${landmark._id}`);
+    })
+);
+
+router.delete(
+    "/:reviewId",
+    catchAsync(async (req, res) => {
+        const { id, reviewId } = req.params;
+        await Landmark.findByIdAndUpdate(id, { $pull: { reviews: reviewId } });
+        await Review.findByIdAndDelete(reviewId);
+        res.redirect(`/landmarks/${id}`);
+    })
+);
+
+module.exports = router;


### PR DESCRIPTION
Splitting out routes for ease of management and code readability. 